### PR TITLE
cmd/brew-emacs: Write files to dunn/homebrew-emacs

### DIFF
--- a/cmd/brew-emacs.rb
+++ b/cmd/brew-emacs.rb
@@ -38,7 +38,7 @@ def template(name)
 end
 
 ARGV.each do |new|
-  @formula_file = (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-emacs/Formula/#{new}.rb")
+  @formula_file = (HOMEBREW_LIBRARY/"Taps/dunn/homebrew-emacs/Formula/#{new}.rb")
   @formula_file.write template(new)
 end
 


### PR DESCRIPTION
Currently, it will recreate the homebrew/homebrew-emacs/Formula
directory and write any newly created files there.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>