### PR TITLE
EmacsRequirement: remove `default_formula`

### DIFF
--- a/Formula/slime.rb
+++ b/Formula/slime.rb
@@ -2,7 +2,6 @@ require File.expand_path("../../Homebrew/emacs_formula", __FILE__)
 
 class CommonLispRequirement < Requirement
   fatal true
-  default_formula "sbcl"
 
   # Based on ordering of available implementations from
   # https://common-lisp.net/project/slime/; except for SBCL which is

--- a/Homebrew/requirements/emacs_requirement.rb
+++ b/Homebrew/requirements/emacs_requirement.rb
@@ -1,6 +1,5 @@
 class EmacsRequirement < Requirement
   fatal true
-  default_formula "emacs"
 
   def initialize(tags)
     @version = tags.shift if /\d+\.*\d*/ =~ tags.first


### PR DESCRIPTION
Deprecated in https://github.com/Homebrew/brew/pull/3724

Fixes https://github.com/dunn/homebrew-emacs/issues/724