### PR TITLE
Fix .undent deprecations

### DIFF
--- a/Formula/ace-window.rb
+++ b/Formula/ace-window.rb
@@ -23,7 +23,7 @@ class AceWindow < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/avy"].opt_elisp}")
       (load "ace-window")

--- a/Formula/ack-emacs.rb
+++ b/Formula/ack-emacs.rb
@@ -15,7 +15,7 @@ class AckEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ack")
       (ack-skel-file)

--- a/Formula/ada-mode.rb
+++ b/Formula/ada-mode.rb
@@ -30,7 +30,7 @@ class AdaMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["wisi"].opt_elisp}")
       (load "ada-mode")

--- a/Formula/adaptive-wrap.rb
+++ b/Formula/adaptive-wrap.rb
@@ -16,7 +16,7 @@ class AdaptiveWrap < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "adaptive-wrap")
       (adaptive-wrap-prefix-mode 1)

--- a/Formula/adjust-parens.rb
+++ b/Formula/adjust-parens.rb
@@ -14,7 +14,7 @@ class AdjustParens < EmacsFormula
                                                     Dir["*.elc"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'adjust-parens)
@@ -24,7 +24,7 @@ class AdjustParens < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/adjust-parens")
       (load "adjust-parens")
       (adjust-parens-mode 1)

--- a/Formula/ag-emacs.rb
+++ b/Formula/ag-emacs.rb
@@ -19,7 +19,7 @@ class AgEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/s-emacs"].opt_elisp}")

--- a/Formula/aggressive-indent.rb
+++ b/Formula/aggressive-indent.rb
@@ -24,7 +24,7 @@ class AggressiveIndent < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/aggressive-indent")
       (load "aggressive-indent")
       (global-aggressive-indent-mode 1)

--- a/Formula/ahungry-emacs.rb
+++ b/Formula/ahungry-emacs.rb
@@ -16,7 +16,7 @@ class AhungryEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'custom-theme-load-path "#{elisp}")
       (load-theme 'ahungry t)
       (print (minibuffer-prompt-width))

--- a/Formula/all-emacs.rb
+++ b/Formula/all-emacs.rb
@@ -15,7 +15,7 @@ class AllEmacs < EmacsFormula
     (share/"emacs/site-lisp/all").install "all.el", "all.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'all)
@@ -23,7 +23,7 @@ class AllEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/all")
       (load "all")
       (print (minibuffer-prompt-width))

--- a/Formula/android-mode.rb
+++ b/Formula/android-mode.rb
@@ -18,7 +18,7 @@ class AndroidMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "android-mode")

--- a/Formula/ansi-emacs.rb
+++ b/Formula/ansi-emacs.rb
@@ -18,7 +18,7 @@ class AnsiEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/s-emacs"].opt_elisp}")

--- a/Formula/ansible-doc.rb
+++ b/Formula/ansible-doc.rb
@@ -24,7 +24,7 @@ class AnsibleDoc < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ansible-doc")
       (print (minibuffer-prompt-width))

--- a/Formula/anzu-mode.rb
+++ b/Formula/anzu-mode.rb
@@ -16,7 +16,7 @@ class AnzuMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "anzu")
       (anzu-mode +1)

--- a/Formula/applescript-mode.rb
+++ b/Formula/applescript-mode.rb
@@ -17,7 +17,7 @@ class ApplescriptMode < EmacsFormula
                                                        "applescript-mode.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'applescript-mode)
@@ -27,7 +27,7 @@ class ApplescriptMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/applescript-mode")
       (load "applescript-mode")
       (print (as-mode-version))

--- a/Formula/ascii-art-to-unicode.rb
+++ b/Formula/ascii-art-to-unicode.rb
@@ -17,7 +17,7 @@ class AsciiArtToUnicode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/ascii-art-to-unicode")
       (load "ascii-art-to-unicode")
       (print (minibuffer-prompt-width))

--- a/Formula/assess-emacs.rb
+++ b/Formula/assess-emacs.rb
@@ -21,7 +21,7 @@ class AssessEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/m-buffer"].opt_elisp}")
       (load "assess")

--- a/Formula/async-emacs.rb
+++ b/Formula/async-emacs.rb
@@ -16,7 +16,7 @@ class AsyncEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "async")
       (let ((fut (async-start

--- a/Formula/auctex.rb
+++ b/Formula/auctex.rb
@@ -28,7 +28,7 @@ class Auctex < Formula
   end
 
   def caveats
-    <<-EOS.undent
+    <<~EOS
     texmf files have been installed into:
       #{HOMEBREW_PREFIX}/share/texmf
 
@@ -38,7 +38,7 @@ class Auctex < Formula
   end
 
   test do
-    (testpath/".emacs").write <<-EOS.undent
+    (testpath/".emacs").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (require 'tex-site)
     EOS

--- a/Formula/aumix-mode.rb
+++ b/Formula/aumix-mode.rb
@@ -17,7 +17,7 @@ class AumixMode < EmacsFormula
                                                  "aumix-mode.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (autoload 'aumix "aumix-mode" nil t)
@@ -25,7 +25,7 @@ class AumixMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/aumix-mode")
       (load "aumix-mode")
       (aumix-mode)

--- a/Formula/auto-complete.rb
+++ b/Formula/auto-complete.rb
@@ -132,7 +132,7 @@ class AutoComplete < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/auto-complete")
       (add-to-list 'load-path "#{Formula["dunn/emacs/popup"].opt_share}/emacs/site-lisp/popup")
 

--- a/Formula/auto-overlays.rb
+++ b/Formula/auto-overlays.rb
@@ -29,7 +29,7 @@ class AutoOverlays < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "auto-overlays")
       (print (minibuffer-prompt-width))

--- a/Formula/avy.rb
+++ b/Formula/avy.rb
@@ -16,7 +16,7 @@ class Avy < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "avy")
       (avy-setup-default)

--- a/Formula/beacon-mode.rb
+++ b/Formula/beacon-mode.rb
@@ -20,7 +20,7 @@ class BeaconMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/seq"].opt_elisp}")
       (load "beacon")

--- a/Formula/browse-kill-ring.rb
+++ b/Formula/browse-kill-ring.rb
@@ -17,7 +17,7 @@ class BrowseKillRing < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/browse-kill-ring")
       (load "browse-kill-ring")
       (browse-kill-ring-default-keybindings)

--- a/Formula/bundler-emacs.rb
+++ b/Formula/bundler-emacs.rb
@@ -25,7 +25,7 @@ class BundlerEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/inf-ruby"].opt_elisp}")
       (load "bundler")

--- a/Formula/buttercup.rb
+++ b/Formula/buttercup.rb
@@ -20,7 +20,7 @@ class Buttercup < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "buttercup")
       (print (minibuffer-prompt-width))

--- a/Formula/caps-lock-emacs.rb
+++ b/Formula/caps-lock-emacs.rb
@@ -17,7 +17,7 @@ class CapsLockEmacs < EmacsFormula
                                                 "caps-lock.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'caps-lock)
@@ -25,7 +25,7 @@ class CapsLockEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/caps-lock")
       (load "caps-lock")
       (print caps-lock-commands)

--- a/Formula/cargo-mode.rb
+++ b/Formula/cargo-mode.rb
@@ -19,7 +19,7 @@ class CargoMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/rust-mode"].opt_elisp}")
       (load "cargo")

--- a/Formula/chess-emacs.rb
+++ b/Formula/chess-emacs.rb
@@ -19,7 +19,7 @@ class ChessEmacs < EmacsFormula
     info.install "chess.info"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'chess)
@@ -27,7 +27,7 @@ class ChessEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/chess")
       (load "chess")
       (print chess-version)

--- a/Formula/cider.rb
+++ b/Formula/cider.rb
@@ -23,7 +23,7 @@ class Cider < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/clojure-mode"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")

--- a/Formula/circe.rb
+++ b/Formula/circe.rb
@@ -20,7 +20,7 @@ class Circe < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "circe")

--- a/Formula/cl-generic.rb
+++ b/Formula/cl-generic.rb
@@ -17,7 +17,7 @@ class ClGeneric < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "cl-generic")
       (print (minibuffer-prompt-width))

--- a/Formula/cl-lib.rb
+++ b/Formula/cl-lib.rb
@@ -23,7 +23,7 @@ class ClLib < EmacsFormula
   end
 
   if Emacs.version >= Version.create("24.3")
-    def caveats; <<-EOS.undent
+    def caveats; <<~EOS
       Warning: Emacs 24.3 and higher includes cl-lib
 
       Installing the compatibility library in parallel can have unexpected consequences.
@@ -33,7 +33,7 @@ class ClLib < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "cl-lib")
       (print (cl-typep "homebrew" 'string))

--- a/Formula/cloc-emacs.rb
+++ b/Formula/cloc-emacs.rb
@@ -15,7 +15,7 @@ class ClocEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/cloc")
       (load "cloc")
       (print (minibuffer-prompt-width))

--- a/Formula/clojure-mode.rb
+++ b/Formula/clojure-mode.rb
@@ -30,7 +30,7 @@ class ClojureMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "clojure-mode")
       (print clojure-mode-version)

--- a/Formula/coffee-mode.rb
+++ b/Formula/coffee-mode.rb
@@ -18,7 +18,7 @@ class CoffeeMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/coffee-mode")
       (load "coffee-mode")
       (print (coffee-version))

--- a/Formula/commander-emacs.rb
+++ b/Formula/commander-emacs.rb
@@ -19,7 +19,7 @@ class CommanderEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/f"].opt_elisp}")

--- a/Formula/company-mode.rb
+++ b/Formula/company-mode.rb
@@ -118,7 +118,7 @@ class CompanyMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "company")

--- a/Formula/context-coloring.rb
+++ b/Formula/context-coloring.rb
@@ -30,7 +30,7 @@ class ContextColoring < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["js2-mode"].opt_elisp}")
       (load "context-coloring")

--- a/Formula/crisp.rb
+++ b/Formula/crisp.rb
@@ -17,7 +17,7 @@ class Crisp < EmacsFormula
                                             "crisp.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'crisp)
@@ -25,7 +25,7 @@ class Crisp < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/crisp")
       (load "crisp")
       (crisp-mode)

--- a/Formula/csharp-mode.rb
+++ b/Formula/csharp-mode.rb
@@ -23,7 +23,7 @@ class CsharpMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "csharp-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/csv-mode.rb
+++ b/Formula/csv-mode.rb
@@ -17,7 +17,7 @@ class CsvMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/csv-mode")
       (load "csv-mode")
       (csv-toggle-descending)

--- a/Formula/cython-mode.rb
+++ b/Formula/cython-mode.rb
@@ -23,7 +23,7 @@ class CythonMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "cython-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/d-mode.rb
+++ b/Formula/d-mode.rb
@@ -24,7 +24,7 @@ class DMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "d-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/darkroom-mode.rb
+++ b/Formula/darkroom-mode.rb
@@ -17,7 +17,7 @@ class DarkroomMode < EmacsFormula
     doc.install "README.md" if build.head?
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'darkroom)
@@ -25,7 +25,7 @@ class DarkroomMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/darkroom")
       (load "darkroom")
       (darkroom-tentative-mode)

--- a/Formula/dart-mode.rb
+++ b/Formula/dart-mode.rb
@@ -24,7 +24,7 @@ class DartMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/flycheck"].opt_elisp}")

--- a/Formula/dash-emacs.rb
+++ b/Formula/dash-emacs.rb
@@ -18,7 +18,7 @@ class DashEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "dash")
       (print (--map (* it it) '(1 2 3 4)))

--- a/Formula/dbus-codegen.rb
+++ b/Formula/dbus-codegen.rb
@@ -18,7 +18,7 @@ class DbusCodegen < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/dbus-codegen")
       (load "dbus-codegen")
       (print (minibuffer-prompt-width))

--- a/Formula/debbugs.rb
+++ b/Formula/debbugs.rb
@@ -17,7 +17,7 @@ class Debbugs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "debbugs")
       (print (car debbugs-servers))

--- a/Formula/deferred.rb
+++ b/Formula/deferred.rb
@@ -24,7 +24,7 @@ class Deferred < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "deferred")
       (print deferred:version)

--- a/Formula/dict-tree.rb
+++ b/Formula/dict-tree.rb
@@ -20,7 +20,7 @@ class DictTree < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["trie-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["heap-emacs"].opt_elisp}")

--- a/Formula/diff-hl.rb
+++ b/Formula/diff-hl.rb
@@ -16,7 +16,7 @@ class DiffHl < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "diff-hl")
       (turn-on-diff-hl-mode)

--- a/Formula/diffview.rb
+++ b/Formula/diffview.rb
@@ -17,7 +17,7 @@ class Diffview < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "diffview")
       (print (minibuffer-prompt-width))

--- a/Formula/diminish.rb
+++ b/Formula/diminish.rb
@@ -15,7 +15,7 @@ class Diminish < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "diminish")
       (print (minibuffer-prompt-width))

--- a/Formula/dismal-mode.rb
+++ b/Formula/dismal-mode.rb
@@ -15,7 +15,7 @@ class DismalMode < EmacsFormula
     doc.install "README", Dir["*.txt"], Dir["*.texi"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add something like the following to your init file:
 
     (setq dismal-directory "#{ENV["HOME"]}/Documents/dismal")
@@ -24,7 +24,7 @@ class DismalMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/dismal")
       (setq dismal-directory "#{doc}")
       (load "dismal")

--- a/Formula/djvu-emacs.rb
+++ b/Formula/djvu-emacs.rb
@@ -15,7 +15,7 @@ class DjvuEmacs < EmacsFormula
     (share/"emacs/site-lisp/djvu").install "djvu.el", "djvu.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'djvu)
@@ -23,7 +23,7 @@ class DjvuEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/djvu")
       (load "djvu")
       (print (minibuffer-prompt-width))

--- a/Formula/docbook-emacs.rb
+++ b/Formula/docbook-emacs.rb
@@ -15,7 +15,7 @@ class DocbookEmacs < EmacsFormula
                                               "docbook.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'docbook)
@@ -23,7 +23,7 @@ class DocbookEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/docbook")
       (load "docbook")
       (print (minibuffer-prompt-width))

--- a/Formula/dockerfile-mode.rb
+++ b/Formula/dockerfile-mode.rb
@@ -15,7 +15,7 @@ class DockerfileMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "dockerfile-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/dracula-emacs.rb
+++ b/Formula/dracula-emacs.rb
@@ -16,7 +16,7 @@ class DraculaEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'custom-theme-load-path "#{elisp}")
       (load-theme 'dracula t)
       (print (minibuffer-prompt-width))

--- a/Formula/easy-kill.rb
+++ b/Formula/easy-kill.rb
@@ -17,7 +17,7 @@ class EasyKill < EmacsFormula
     doc.install "README.rst"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'easy-kill)
@@ -26,7 +26,7 @@ class EasyKill < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/easy-kill")
       (load "easy-kill")
       (print (minibuffer-prompt-width))

--- a/Formula/ediprolog.rb
+++ b/Formula/ediprolog.rb
@@ -15,7 +15,7 @@ class Ediprolog < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ediprolog")
       (print ediprolog-version)

--- a/Formula/editorconfig-emacs.rb
+++ b/Formula/editorconfig-emacs.rb
@@ -30,7 +30,7 @@ class EditorconfigEmacs < EmacsFormula
 
   def caveats
     if build.without? "editorconfig"
-      <<-EOS.undent
+      <<~EOS
       Set the Emacs variable `editorconfig-exec-path' to
         #{HOMEBREW_PREFIX}/bin/editorconfig-el
       EOS
@@ -38,7 +38,7 @@ class EditorconfigEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "editorconfig")
       (editorconfig-mode 1)

--- a/Formula/el-mock.rb
+++ b/Formula/el-mock.rb
@@ -15,7 +15,7 @@ class ElMock < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "el-mock")
       (print (minibuffer-prompt-width))

--- a/Formula/el-x.rb
+++ b/Formula/el-x.rb
@@ -16,7 +16,7 @@ class ElX < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "el-x")
       (print (minibuffer-prompt-width))

--- a/Formula/eldoc-eval.rb
+++ b/Formula/eldoc-eval.rb
@@ -15,7 +15,7 @@ class EldocEval < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "eldoc-eval")
       (print (minibuffer-prompt-width))

--- a/Formula/electric-spacing.rb
+++ b/Formula/electric-spacing.rb
@@ -15,7 +15,7 @@ class ElectricSpacing < EmacsFormula
                                                        "electric-spacing.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'electric-spacing)
@@ -23,7 +23,7 @@ class ElectricSpacing < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/electric-spacing")
       (load "electric-spacing")
       (print (minibuffer-prompt-width))

--- a/Formula/elfeed.rb
+++ b/Formula/elfeed.rb
@@ -19,7 +19,7 @@ class Elfeed < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "elfeed")
       (print elfeed-version)

--- a/Formula/elisp-bug-hunter.rb
+++ b/Formula/elisp-bug-hunter.rb
@@ -22,7 +22,7 @@ class ElispBugHunter < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/seq"].opt_elisp}")
       (load "bug-hunter")

--- a/Formula/elisp-slime-nav.rb
+++ b/Formula/elisp-slime-nav.rb
@@ -15,7 +15,7 @@ class ElispSlimeNav < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "elisp-slime-nav")
       (turn-on-elisp-slime-nav-mode)

--- a/Formula/emmet-mode.rb
+++ b/Formula/emmet-mode.rb
@@ -16,7 +16,7 @@ class EmmetMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "emmet-mode")
       (print emmet-mode:version)

--- a/Formula/enwc.rb
+++ b/Formula/enwc.rb
@@ -23,7 +23,7 @@ class Enwc < EmacsFormula
     doc.install Dir["doc/*"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'enwc-setup)
@@ -32,7 +32,7 @@ class Enwc < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/enwc")
       (load "enwc-setup")
       (print (minibuffer-prompt-width))

--- a/Formula/epl.rb
+++ b/Formula/epl.rb
@@ -17,7 +17,7 @@ class Epl < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "elp")
       (print (minibuffer-prompt-width))

--- a/Formula/epoch-view.rb
+++ b/Formula/epoch-view.rb
@@ -15,7 +15,7 @@ class EpochView < EmacsFormula
                                                  "epoch-view.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'epoch-view)
@@ -23,7 +23,7 @@ class EpochView < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/epoch-view")
       (load "epoch-view")
       (epoch-view-turn-on)

--- a/Formula/evil.rb
+++ b/Formula/evil.rb
@@ -22,7 +22,7 @@ class Evil < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "evil")
       (evil-mode 1)

--- a/Formula/exec-path-from-shell.rb
+++ b/Formula/exec-path-from-shell.rb
@@ -15,7 +15,7 @@ class ExecPathFromShell < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "exec-path-from-shell")
       (print (exec-path-from-shell-copy-env "HOME"))

--- a/Formula/f-emacs.rb
+++ b/Formula/f-emacs.rb
@@ -24,7 +24,7 @@ class FEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/s-emacs"].opt_elisp}")

--- a/Formula/f90-interface-browser.rb
+++ b/Formula/f90-interface-browser.rb
@@ -21,7 +21,7 @@ class F90InterfaceBrowser < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "f90-interface-browser")
       (print (minibuffer-prompt-width))

--- a/Formula/flycheck.rb
+++ b/Formula/flycheck.rb
@@ -63,7 +63,7 @@ class Flycheck < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/pkg-info"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")

--- a/Formula/flylisp.rb
+++ b/Formula/flylisp.rb
@@ -15,7 +15,7 @@ class Flylisp < EmacsFormula
                                               "flylisp.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'flylisp)
@@ -23,7 +23,7 @@ class Flylisp < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/flylisp")
       (load "flylisp")
       (print (minibuffer-prompt-width))

--- a/Formula/fountain-mode.rb
+++ b/Formula/fountain-mode.rb
@@ -17,7 +17,7 @@ class FountainMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "fountain-mode")
       (print fountain-version)

--- a/Formula/ggtags.rb
+++ b/Formula/ggtags.rb
@@ -23,7 +23,7 @@ class Ggtags < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/ggtags")
       (load "ggtags")
       (print (minibuffer-prompt-width))

--- a/Formula/gh-emacs.rb
+++ b/Formula/gh-emacs.rb
@@ -18,7 +18,7 @@ class GhEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/logito"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/pcache"].opt_elisp}")

--- a/Formula/gist-emacs.rb
+++ b/Formula/gist-emacs.rb
@@ -18,7 +18,7 @@ class GistEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/gh-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/logito"].opt_elisp}")

--- a/Formula/git-messenger.rb
+++ b/Formula/git-messenger.rb
@@ -24,7 +24,7 @@ class GitMessenger < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/git-messenger")
       (add-to-list 'load-path "#{Formula["popup"].opt_share}/emacs/site-lisp/popup")
       (load "git-messenger")

--- a/Formula/git-modes.rb
+++ b/Formula/git-modes.rb
@@ -21,7 +21,7 @@ class GitModes < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "git-modes")
       (gitattributes-mode-help)

--- a/Formula/gnorb.rb
+++ b/Formula/gnorb.rb
@@ -20,7 +20,7 @@ class Gnorb < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "gnorb")
       (print (minibuffer-prompt-width))

--- a/Formula/gnugo-emacs.rb
+++ b/Formula/gnugo-emacs.rb
@@ -22,7 +22,7 @@ class GnugoEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "gnugo")
       (print gnugo-version)

--- a/Formula/go-mode.rb
+++ b/Formula/go-mode.rb
@@ -16,7 +16,7 @@ class GoMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "go-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/groovy-mode.rb
+++ b/Formula/groovy-mode.rb
@@ -17,14 +17,14 @@ class GroovyMode < EmacsFormula
     prefix.install "gpl-3.0.txt"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Grails mode was not installed, as it currently has additional dependencies
     not available in Homebrew.
   EOS
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "groovy-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/haskell-mode.rb
+++ b/Formula/haskell-mode.rb
@@ -35,7 +35,7 @@ class HaskellMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "haskell-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/heap-emacs.rb
+++ b/Formula/heap-emacs.rb
@@ -17,7 +17,7 @@ class HeapEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "heap")
       (print (minibuffer-prompt-width))

--- a/Formula/helm.rb
+++ b/Formula/helm.rb
@@ -18,7 +18,7 @@ class Helm < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/async-emacs"].opt_elisp}")
       (load "helm-config")

--- a/Formula/homebrew-mode.rb
+++ b/Formula/homebrew-mode.rb
@@ -22,7 +22,7 @@ class HomebrewMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/homebrew-mode")
       (add-to-list 'load-path "#{Formula["dunn/emacs/inf-ruby"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")

--- a/Formula/htmlize.rb
+++ b/Formula/htmlize.rb
@@ -24,7 +24,7 @@ class Htmlize < EmacsFormula
   test do
     (testpath/"test.txt").write "hello"
 
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "htmlize")
       (htmlize-file "#{testpath}/test.txt" "#{testpath}/out.html")

--- a/Formula/hydra-emacs.rb
+++ b/Formula/hydra-emacs.rb
@@ -16,7 +16,7 @@ class HydraEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "hydra")
       (defhydra hydra-zoom (global-map "<f2>")

--- a/Formula/inf-ruby.rb
+++ b/Formula/inf-ruby.rb
@@ -17,7 +17,7 @@ class InfRuby < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "inf-ruby")
       (print (minibuffer-prompt-width))

--- a/Formula/irony-mode.rb
+++ b/Formula/irony-mode.rb
@@ -35,7 +35,7 @@ class IronyMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "irony")

--- a/Formula/javaimp.rb
+++ b/Formula/javaimp.rb
@@ -16,7 +16,7 @@ class Javaimp < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/seq"].opt_elisp}")
       (load "javaimp")

--- a/Formula/jgraph-mode.rb
+++ b/Formula/jgraph-mode.rb
@@ -16,7 +16,7 @@ class JgraphMode < EmacsFormula
                                                   "jgraph-mode.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'jgraph-mode)
@@ -24,7 +24,7 @@ class JgraphMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/jgraph-mode")
       (load "jgraph-mode")
       (print jgraph-commands)

--- a/Formula/json-mode.rb
+++ b/Formula/json-mode.rb
@@ -19,7 +19,7 @@ class JsonMode < EmacsFormula
   test do
     (testpath/"test.json").write '{ "home": "brew" }'
 
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dunn/emacs/json-reformat"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/json-snatcher"].opt_elisp}")
       (add-to-list 'load-path "#{elisp}")

--- a/Formula/json-reformat.rb
+++ b/Formula/json-reformat.rb
@@ -17,7 +17,7 @@ class JsonReformat < EmacsFormula
   test do
     (testpath/"test.json").write '{ "home": "brew" }'
 
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "json-reformat")
       (find-file "#{testpath}/test.json")

--- a/Formula/json-snatcher.rb
+++ b/Formula/json-snatcher.rb
@@ -15,7 +15,7 @@ class JsonSnatcher < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "json-snatcher")
       (print (jsons-is-number "808"))

--- a/Formula/jumpc.rb
+++ b/Formula/jumpc.rb
@@ -15,7 +15,7 @@ class Jumpc < EmacsFormula
                                             "jumpc.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'jumpc)
@@ -25,7 +25,7 @@ class Jumpc < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/jumpc")
       (load "jumpc")
       (jumpc)

--- a/Formula/keyfreq.rb
+++ b/Formula/keyfreq.rb
@@ -16,7 +16,7 @@ class Keyfreq < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/keyfreq")
       (load "keyfreq")
       (keyfreq-autosave-mode 1)

--- a/Formula/know-your-http-well.rb
+++ b/Formula/know-your-http-well.rb
@@ -19,7 +19,7 @@ class KnowYourHttpWell < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "know-your-http-well")
       (print (http-status-code "500"))

--- a/Formula/landmark-emacs.rb
+++ b/Formula/landmark-emacs.rb
@@ -16,7 +16,7 @@ class LandmarkEmacs < EmacsFormula
                                                "landmark.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'landmark)
@@ -24,7 +24,7 @@ class LandmarkEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/landmark")
       (load "landmark")
       (landmark-test-run)

--- a/Formula/ledger-mode.rb
+++ b/Formula/ledger-mode.rb
@@ -24,7 +24,7 @@ class LedgerMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ledger-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/less-css-mode.rb
+++ b/Formula/less-css-mode.rb
@@ -22,7 +22,7 @@ class LessCssMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "less-css-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/let-alist.rb
+++ b/Formula/let-alist.rb
@@ -17,7 +17,7 @@ class LetAlist < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "let-alist")
       (print

--- a/Formula/lex-emacs.rb
+++ b/Formula/lex-emacs.rb
@@ -15,7 +15,7 @@ class LexEmacs < EmacsFormula
                                           Dir["*.elc"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'lex)
@@ -23,7 +23,7 @@ class LexEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/lex")
       (load "lex")
       (print (minibuffer-prompt-width))

--- a/Formula/list-unicode-display.rb
+++ b/Formula/list-unicode-display.rb
@@ -23,7 +23,7 @@ class ListUnicodeDisplay < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "list-unicode-display")

--- a/Formula/lmc-emacs.rb
+++ b/Formula/lmc-emacs.rb
@@ -16,7 +16,7 @@ class LmcEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "lmc")
       (print (minibuffer-prompt-width))

--- a/Formula/load-dir.rb
+++ b/Formula/load-dir.rb
@@ -17,7 +17,7 @@ class LoadDir < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "load-dir")
       (load-dir-one "#{elisp}")

--- a/Formula/load-relative.rb
+++ b/Formula/load-relative.rb
@@ -28,7 +28,7 @@ class LoadRelative < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/load-relative")
       (load "load-relative")
       (print (minibuffer-prompt-width))

--- a/Formula/loc-changes.rb
+++ b/Formula/loc-changes.rb
@@ -30,7 +30,7 @@ class LocChanges < EmacsFormula
                                                   "loc-changes.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'loc-changes)
@@ -38,7 +38,7 @@ class LocChanges < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/loc-changes")
       (load "loc-changes")
       (print (minibuffer-prompt-width))

--- a/Formula/logito.rb
+++ b/Formula/logito.rb
@@ -15,7 +15,7 @@ class Logito < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "logito")
       (print (minibuffer-prompt-width))

--- a/Formula/loop-emacs.rb
+++ b/Formula/loop-emacs.rb
@@ -15,7 +15,7 @@ class LoopEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "loop")
       (print (let ((x 0) (sum 0))

--- a/Formula/m-buffer.rb
+++ b/Formula/m-buffer.rb
@@ -21,7 +21,7 @@ class MBuffer < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "m-buffer")
       (print (minibuffer-prompt-width))

--- a/Formula/magit.rb
+++ b/Formula/magit.rb
@@ -66,7 +66,7 @@ class Magit < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/async-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")

--- a/Formula/markchars.rb
+++ b/Formula/markchars.rb
@@ -15,7 +15,7 @@ class Markchars < EmacsFormula
                                                 "markchars.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'markchars)
@@ -23,7 +23,7 @@ class Markchars < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/markchars")
       (load "markchars")
       (markchars-mode 1)

--- a/Formula/markdown-mode.rb
+++ b/Formula/markdown-mode.rb
@@ -56,7 +56,7 @@ class MarkdownMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (require 'markdown-mode)
       (print (minibuffer-prompt-width))

--- a/Formula/mastodon-mode.rb
+++ b/Formula/mastodon-mode.rb
@@ -21,7 +21,7 @@ class MastodonMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "mastodon")
       (print (minibuffer-prompt-width))

--- a/Formula/memory-usage-emacs.rb
+++ b/Formula/memory-usage-emacs.rb
@@ -15,7 +15,7 @@ class MemoryUsageEmacs < EmacsFormula
                                                    "memory-usage.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'memory-usage)
@@ -23,7 +23,7 @@ class MemoryUsageEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/memory-usage")
       (load "memory-usage")
       (memory-usage)

--- a/Formula/metar-emacs.rb
+++ b/Formula/metar-emacs.rb
@@ -16,7 +16,7 @@ class MetarEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "metar")

--- a/Formula/minibuffer-line.rb
+++ b/Formula/minibuffer-line.rb
@@ -15,7 +15,7 @@ class MinibufferLine < EmacsFormula
                                                       "minibuffer-line.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'minibuffer-line)
@@ -23,7 +23,7 @@ class MinibufferLine < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/minibuffer-line")
       (load "minibuffer-line")
       (print (minibuffer-prompt-width))

--- a/Formula/minimap-emacs.rb
+++ b/Formula/minimap-emacs.rb
@@ -15,7 +15,7 @@ class MinimapEmacs < EmacsFormula
                                               "minimap.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'minimap)
@@ -23,7 +23,7 @@ class MinimapEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/minimap")
       (load "minimap")
       (print (minibuffer-prompt-width))

--- a/Formula/minitest-emacs.rb
+++ b/Formula/minitest-emacs.rb
@@ -24,7 +24,7 @@ class MinitestEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (load "minitest")

--- a/Formula/mmm-mode.rb
+++ b/Formula/mmm-mode.rb
@@ -22,7 +22,7 @@ class MmmMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "mmm-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/mocha-emacs.rb
+++ b/Formula/mocha-emacs.rb
@@ -21,7 +21,7 @@ class MochaEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/js2-mode"].opt_elisp}")
       (load "mocha")

--- a/Formula/mocker.rb
+++ b/Formula/mocker.rb
@@ -18,7 +18,7 @@ class Mocker < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "mocker")
       (print (minibuffer-prompt-width))

--- a/Formula/multiple-cursors.rb
+++ b/Formula/multiple-cursors.rb
@@ -15,7 +15,7 @@ class MultipleCursors < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "multiple-cursors")
       (print (minibuffer-prompt-width))

--- a/Formula/muse.rb
+++ b/Formula/muse.rb
@@ -32,7 +32,7 @@ class Muse < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "muse-mode")
       (load "muse-project")

--- a/Formula/names.rb
+++ b/Formula/names.rb
@@ -16,7 +16,7 @@ class Names < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/names")
       (load "names")
       (print (minibuffer-prompt-width))

--- a/Formula/neotree.rb
+++ b/Formula/neotree.rb
@@ -17,7 +17,7 @@ class Neotree < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "neotree")
       (print (minibuffer-prompt-width))

--- a/Formula/nhexl-mode.rb
+++ b/Formula/nhexl-mode.rb
@@ -16,7 +16,7 @@ class NhexlMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "nhexl-mode")
       (nhexl-mode)

--- a/Formula/nix-mode.rb
+++ b/Formula/nix-mode.rb
@@ -24,7 +24,7 @@ class NixMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "nix-mode")
       (nix-mode)

--- a/Formula/nlinum.rb
+++ b/Formula/nlinum.rb
@@ -17,7 +17,7 @@ class Nlinum < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "nlinum")
       (nlinum-mode)

--- a/Formula/num3-mode.rb
+++ b/Formula/num3-mode.rb
@@ -15,7 +15,7 @@ class Num3Mode < EmacsFormula
                                                 "num3-mode.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'num3-mode)
@@ -24,7 +24,7 @@ class Num3Mode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/num3-mode")
       (load "num3-mode")
       (global-num3-mode)

--- a/Formula/oauth2-emacs.rb
+++ b/Formula/oauth2-emacs.rb
@@ -15,7 +15,7 @@ class Oauth2Emacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "oauth2")
       (print (minibuffer-prompt-width))

--- a/Formula/olivetti.rb
+++ b/Formula/olivetti.rb
@@ -17,7 +17,7 @@ class Olivetti < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/olivetti")
       (load "olivetti")
       (olivetti-mode 1)

--- a/Formula/omn-mode.rb
+++ b/Formula/omn-mode.rb
@@ -15,7 +15,7 @@ class OmnMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/omn-mode")
       (load "omn-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/org-mode.rb
+++ b/Formula/org-mode.rb
@@ -43,7 +43,7 @@ class OrgMode < EmacsFormula
     system "make", "all"
 
     rm "local.mk"
-    (buildpath/"local.mk").write <<-EOS.undent
+    (buildpath/"local.mk").write <<~EOS
       prefix  = #{prefix}
       lispdir = #{elisp}
       datadir = #{etc}/emacs/#{name}
@@ -57,7 +57,7 @@ class OrgMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "org")
       (print (minibuffer-prompt-width))

--- a/Formula/osc-emacs.rb
+++ b/Formula/osc-emacs.rb
@@ -17,7 +17,7 @@ class OscEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/osc")
       (load "osc")
       (setq pid (osc-make-client "localhost" "8080"))

--- a/Formula/pabbrev.rb
+++ b/Formula/pabbrev.rb
@@ -18,7 +18,7 @@ class Pabbrev < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "pabbrev")
       (print (minibuffer-prompt-width))

--- a/Formula/package-lint.rb
+++ b/Formula/package-lint.rb
@@ -21,7 +21,7 @@ class PackageLint < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "package-lint")
       (print (minibuffer-prompt-width))

--- a/Formula/pandoc-mode.rb
+++ b/Formula/pandoc-mode.rb
@@ -26,7 +26,7 @@ class PandocMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/hydra-emacs"].opt_elisp}")

--- a/Formula/pass-mode.rb
+++ b/Formula/pass-mode.rb
@@ -22,7 +22,7 @@ class PassMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["pass"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/f-emacs"].opt_elisp}")

--- a/Formula/pcache.rb
+++ b/Formula/pcache.rb
@@ -23,7 +23,7 @@ class Pcache < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "pcache")
       (print (let ((repo (pcache-repository "plop")))

--- a/Formula/pdf-tools.rb
+++ b/Formula/pdf-tools.rb
@@ -27,14 +27,14 @@ class PdfTools < EmacsFormula
     elisp.install Dir["lisp/pdf*.el"], Dir["lisp/pdf*.elc"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Set the variable `pdf-info-epdfinfo-program' to
       #{HOMEBREW_PREFIX}/bin/epdfinfo
   EOS
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/let-alist"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/tablist"].opt_elisp}")

--- a/Formula/php-mode.rb
+++ b/Formula/php-mode.rb
@@ -17,7 +17,7 @@ class PhpMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (require 'php-mode)
       (print php-mode-version-number)

--- a/Formula/pkg-info.rb
+++ b/Formula/pkg-info.rb
@@ -19,7 +19,7 @@ class PkgInfo < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/pkg-info")
       (add-to-list 'load-path "#{Formula["dunn/emacs/epl"].opt_share}/emacs/site-lisp/epl")
       (load "pkg-info")

--- a/Formula/pmd-emacs.rb
+++ b/Formula/pmd-emacs.rb
@@ -18,7 +18,7 @@ class PmdEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "pmd")
       (print (minibuffer-prompt-width))

--- a/Formula/poker-emacs.rb
+++ b/Formula/poker-emacs.rb
@@ -23,7 +23,7 @@ class PokerEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "poker")
       (print (poker-random-deck))

--- a/Formula/popup.rb
+++ b/Formula/popup.rb
@@ -24,7 +24,7 @@ class Popup < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "popup")
       (print popup-version)

--- a/Formula/pos-tip.rb
+++ b/Formula/pos-tip.rb
@@ -15,7 +15,7 @@ class PosTip < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "pos-tip")
       (print pos-tip-version)

--- a/Formula/powerline-emacs.rb
+++ b/Formula/powerline-emacs.rb
@@ -16,7 +16,7 @@ class PowerlineEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "powerline")
       (powerline-default-theme)

--- a/Formula/projectile.rb
+++ b/Formula/projectile.rb
@@ -18,7 +18,7 @@ class Projectile < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/epl"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/pkg-info"].opt_elisp}")

--- a/Formula/puppet-mode.rb
+++ b/Formula/puppet-mode.rb
@@ -17,7 +17,7 @@ class PuppetMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (require 'puppet-mode)
       (print (minibuffer-prompt-width))

--- a/Formula/quarter-plane.rb
+++ b/Formula/quarter-plane.rb
@@ -15,7 +15,7 @@ class QuarterPlane < EmacsFormula
                                                     "quarter-plane.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'quarter-plane)
@@ -23,7 +23,7 @@ class QuarterPlane < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/quarter-plane")
       (load "quarter-plane")
       (quarter-plane-delete-whitespace)

--- a/Formula/queue-emacs.rb
+++ b/Formula/queue-emacs.rb
@@ -17,7 +17,7 @@ class QueueEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "queue")
       (print (minibuffer-prompt-width))

--- a/Formula/rainbow-delimiters.rb
+++ b/Formula/rainbow-delimiters.rb
@@ -17,7 +17,7 @@ class RainbowDelimiters < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "rainbow-delimiters")
       (rainbow-delimiters-mode-enable)

--- a/Formula/rainbow-mode.rb
+++ b/Formula/rainbow-mode.rb
@@ -16,7 +16,7 @@ class RainbowMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "rainbow-mode")
       (rainbow-mode 1)

--- a/Formula/ranger-emacs.rb
+++ b/Formula/ranger-emacs.rb
@@ -17,7 +17,7 @@ class RangerEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ranger")
       (print (minibuffer-prompt-width))

--- a/Formula/rdf-prefix.rb
+++ b/Formula/rdf-prefix.rb
@@ -15,7 +15,7 @@ class RdfPrefix < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "rdf-prefix")
       (print (rdf-prefix-lookup "bf"))

--- a/Formula/realgud.rb
+++ b/Formula/realgud.rb
@@ -55,7 +55,7 @@ class Realgud < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dunn/emacs/load-relative"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/loc-changes"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/test-simple"].opt_elisp}")

--- a/Formula/register-list.rb
+++ b/Formula/register-list.rb
@@ -15,7 +15,7 @@ class RegisterList < EmacsFormula
                                                     "register-list.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'register-list)
@@ -23,7 +23,7 @@ class RegisterList < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/register-list")
       (load "register-list")
       (print (minibuffer-prompt-width))

--- a/Formula/request-emacs.rb
+++ b/Formula/request-emacs.rb
@@ -17,7 +17,7 @@ class RequestEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "request")
       (print request-version)

--- a/Formula/robe.rb
+++ b/Formula/robe.rb
@@ -21,7 +21,7 @@ class Robe < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["inf-ruby"].opt_elisp}")
       (load "robe")

--- a/Formula/rspec-mode.rb
+++ b/Formula/rspec-mode.rb
@@ -18,7 +18,7 @@ class RspecMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "rspec-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/rubocop-emacs.rb
+++ b/Formula/rubocop-emacs.rb
@@ -16,7 +16,7 @@ class RubocopEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{elisp}")
       (load "rubocop")

--- a/Formula/ruby-tools.rb
+++ b/Formula/ruby-tools.rb
@@ -22,7 +22,7 @@ class RubyTools < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ruby-tools")
       (print (minibuffer-prompt-width))

--- a/Formula/rust-mode.rb
+++ b/Formula/rust-mode.rb
@@ -26,7 +26,7 @@ class RustMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/rust-mode")
       (load "rust-mode")
       (rust-mode)

--- a/Formula/s-emacs.rb
+++ b/Formula/s-emacs.rb
@@ -18,7 +18,7 @@ class SEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "s")
       (print (s-repeat 4 "omg"))

--- a/Formula/scroll-restore.rb
+++ b/Formula/scroll-restore.rb
@@ -22,7 +22,7 @@ class ScrollRestore < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "scroll-restore")
       (scroll-restore-remove)

--- a/Formula/scss-mode.rb
+++ b/Formula/scss-mode.rb
@@ -15,7 +15,7 @@ class ScssMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "scss-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/seq.rb
+++ b/Formula/seq.rb
@@ -23,7 +23,7 @@ class Seq < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/seq")
       (load "seq")
       (print (seq-max '(1 5 10)))

--- a/Formula/shell-pop.rb
+++ b/Formula/shell-pop.rb
@@ -15,7 +15,7 @@ class ShellPop < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "shell-pop")
       (shell-pop 1)

--- a/Formula/shut-up.rb
+++ b/Formula/shut-up.rb
@@ -15,7 +15,7 @@ class ShutUp < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "shut-up")
       (shut-up

--- a/Formula/simple-httpd.rb
+++ b/Formula/simple-httpd.rb
@@ -18,7 +18,7 @@ class SimpleHttpd < EmacsFormula
     doc.install "README.md"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'simple-httpd)
@@ -26,7 +26,7 @@ class SimpleHttpd < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/simple-httpd")
       (load "simple-httpd")
       (setq httpd-root "#{testpath}")

--- a/Formula/sisu-mode.rb
+++ b/Formula/sisu-mode.rb
@@ -15,7 +15,7 @@ class SisuMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "sisu-mode")
       (sisu-mode)

--- a/Formula/skewer-mode.rb
+++ b/Formula/skewer-mode.rb
@@ -17,7 +17,7 @@ class SkewerMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/skewer-mode")
       (add-to-list 'load-path "#{Formula["dunn/emacs/simple-httpd"].opt_share}/emacs/site-lisp/simple-httpd")
       (add-to-list 'load-path "#{Formula["dunn/emacs/js2-mode"].opt_share}/emacs/site-lisp/js2-mode")

--- a/Formula/slime.rb
+++ b/Formula/slime.rb
@@ -63,7 +63,7 @@ class Slime < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "slime-autoloads")
       (print (minibuffer-prompt-width))

--- a/Formula/smartparens.rb
+++ b/Formula/smartparens.rb
@@ -20,7 +20,7 @@ class Smartparens < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")

--- a/Formula/smex.rb
+++ b/Formula/smex.rb
@@ -15,7 +15,7 @@ class Smex < EmacsFormula
     doc.install "README.markdown"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'smex)
@@ -26,7 +26,7 @@ class Smex < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/smex")
       (require 'smex)
       (smex-initialize)

--- a/Formula/sml-mode.rb
+++ b/Formula/sml-mode.rb
@@ -22,7 +22,7 @@ class SmlMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "sml-mode")
       (sml-mode)

--- a/Formula/soap-client-emacs.rb
+++ b/Formula/soap-client-emacs.rb
@@ -18,7 +18,7 @@ class SoapClientEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/cl-lib"].opt_elisp}")
       (load "soap-client")

--- a/Formula/sokoban-emacs.rb
+++ b/Formula/sokoban-emacs.rb
@@ -16,7 +16,7 @@ class SokobanEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "sokoban")
       (print (minibuffer-prompt-width))

--- a/Formula/solarized-emacs.rb
+++ b/Formula/solarized-emacs.rb
@@ -13,7 +13,7 @@ class SolarizedEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'custom-theme-load-path "#{elisp}")
       (load-theme 'solarized t)
       (setq solarized-termcolors 256)

--- a/Formula/sotlisp.rb
+++ b/Formula/sotlisp.rb
@@ -23,7 +23,7 @@ class Sotlisp < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "sotlisp")
       (print (minibuffer-prompt-width))

--- a/Formula/spinner-emacs.rb
+++ b/Formula/spinner-emacs.rb
@@ -23,7 +23,7 @@ class SpinnerEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "spinner")
       (spinner-start)

--- a/Formula/suggest-emacs.rb
+++ b/Formula/suggest-emacs.rb
@@ -21,7 +21,7 @@ class SuggestEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/f-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/loop-emacs"].opt_elisp}")

--- a/Formula/swiper.rb
+++ b/Formula/swiper.rb
@@ -16,7 +16,7 @@ class Swiper < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "swiper")
       (print (minibuffer-prompt-width))

--- a/Formula/tablist.rb
+++ b/Formula/tablist.rb
@@ -16,7 +16,7 @@ class Tablist < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "tablist")
       (tablist-quit)

--- a/Formula/tawny-mode.rb
+++ b/Formula/tawny-mode.rb
@@ -19,7 +19,7 @@ class TawnyMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["cider"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["clojure-mode"].opt_elisp}")

--- a/Formula/temp-buffer-browse.rb
+++ b/Formula/temp-buffer-browse.rb
@@ -15,7 +15,7 @@ class TempBufferBrowse < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "temp-buffer-browse")
       (temp-buffer-browse-mode 1)

--- a/Formula/tern.rb
+++ b/Formula/tern.rb
@@ -27,7 +27,7 @@ class Tern < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "tern")
       (print (minibuffer-prompt-width))

--- a/Formula/test-simple.rb
+++ b/Formula/test-simple.rb
@@ -29,7 +29,7 @@ class TestSimple < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/test-simple")
       (load "test-simple")
       (print (minibuffer-prompt-width))

--- a/Formula/textmate-emacs.rb
+++ b/Formula/textmate-emacs.rb
@@ -22,7 +22,7 @@ class TextmateEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "textmate")
       (print (minibuffer-prompt-width))

--- a/Formula/timerfunctions.rb
+++ b/Formula/timerfunctions.rb
@@ -15,7 +15,7 @@ class Timerfunctions < EmacsFormula
                                                       "timerfunctions.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'timerfunctions)
@@ -23,7 +23,7 @@ class Timerfunctions < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/timerfunctions")
       (load "timerfunctions")
       (print timerfunctions-version)

--- a/Formula/tiny-emacs.rb
+++ b/Formula/tiny-emacs.rb
@@ -17,7 +17,7 @@ class TinyEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "tiny")
       (print (tiny-tokenize "+x2"))

--- a/Formula/tnfa-emacs.rb
+++ b/Formula/tnfa-emacs.rb
@@ -18,7 +18,7 @@ class TnfaEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["queue-emacs"].opt_elisp}")
       (load "tNFA")

--- a/Formula/trie-emacs.rb
+++ b/Formula/trie-emacs.rb
@@ -20,7 +20,7 @@ class TrieEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/heap-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/tnfa-emacs"].opt_elisp}")

--- a/Formula/twittering-mode.rb
+++ b/Formula/twittering-mode.rb
@@ -23,7 +23,7 @@ class TwitteringMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "twittering-mode")
       (print (twittering-mode-version))

--- a/Formula/typo-mode.rb
+++ b/Formula/typo-mode.rb
@@ -15,7 +15,7 @@ class TypoMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "typo")
       (typo-global-mode 1)

--- a/Formula/undercover.rb
+++ b/Formula/undercover.rb
@@ -17,7 +17,7 @@ class Undercover < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/dash-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{Formula["dunn/emacs/shut-up"].opt_elisp}")

--- a/Formula/undo-tree.rb
+++ b/Formula/undo-tree.rb
@@ -19,7 +19,7 @@ class UndoTree < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "undo-tree")
       (global-undo-tree-mode)

--- a/Formula/unkillable-scratch.rb
+++ b/Formula/unkillable-scratch.rb
@@ -16,7 +16,7 @@ class UnkillableScratch < EmacsFormula
     doc.install "README.md"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'unkillable-scratch)
@@ -25,7 +25,7 @@ class UnkillableScratch < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/unkillable-scratch")
       (load "unkillable-scratch")
       (unkillable-scratch 1)

--- a/Formula/vdiff.rb
+++ b/Formula/vdiff.rb
@@ -31,7 +31,7 @@ class Vdiff < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{Formula["dunn/emacs/hydra-emacs"].opt_elisp}")
       (add-to-list 'load-path "#{elisp}")
       (load "vdiff")

--- a/Formula/vlf-mode.rb
+++ b/Formula/vlf-mode.rb
@@ -15,7 +15,7 @@ class VlfMode < EmacsFormula
     doc.install "README.org"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'vlf-setup)
@@ -23,7 +23,7 @@ class VlfMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/vlf")
       (load "vlf-setup")
       (print (minibuffer-prompt-width))

--- a/Formula/w3.rb
+++ b/Formula/w3.rb
@@ -28,7 +28,7 @@ class W3 < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "w3")
       (w3-fetch "http://brew.sh")

--- a/Formula/wcheck-mode.rb
+++ b/Formula/wcheck-mode.rb
@@ -21,7 +21,7 @@ class WcheckMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "wcheck-mode")
       (print (minibuffer-prompt-width))

--- a/Formula/web-completion-data.rb
+++ b/Formula/web-completion-data.rb
@@ -26,7 +26,7 @@ class WebCompletionData < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "web-completion-data")
       (print web-completion-data-html-source-dir)

--- a/Formula/web-server-emacs.rb
+++ b/Formula/web-server-emacs.rb
@@ -22,7 +22,7 @@ class WebServerEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "web-server")
       (print (minibuffer-prompt-width))

--- a/Formula/websocket-emacs.rb
+++ b/Formula/websocket-emacs.rb
@@ -18,7 +18,7 @@ class WebsocketEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "websocket")
       (print (minibuffer-prompt-width))

--- a/Formula/wgrep.rb
+++ b/Formula/wgrep.rb
@@ -17,7 +17,7 @@ class Wgrep < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/wgrep")
       (load "wgrep")
       (wgrep-check-buffer)

--- a/Formula/which-key.rb
+++ b/Formula/which-key.rb
@@ -18,7 +18,7 @@ class WhichKey < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "which-key")
       (which-key-mode)

--- a/Formula/windresize.rb
+++ b/Formula/windresize.rb
@@ -15,7 +15,7 @@ class Windresize < EmacsFormula
                                                  "windresize.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'windresize)
@@ -23,7 +23,7 @@ class Windresize < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/windresize")
       (load "windresize")
       (print windresize-version)

--- a/Formula/wisi.rb
+++ b/Formula/wisi.rb
@@ -17,7 +17,7 @@ class Wisi < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "wisi")
       (print (minibuffer-prompt-width))

--- a/Formula/wpuzzle.rb
+++ b/Formula/wpuzzle.rb
@@ -16,7 +16,7 @@ class Wpuzzle < EmacsFormula
                                               "wpuzzle.elc"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'wpuzzle)
@@ -24,7 +24,7 @@ class Wpuzzle < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/wpuzzle")
       (load "wpuzzle")
       (print (minibuffer-prompt-width))

--- a/Formula/xclip-mode.rb
+++ b/Formula/xclip-mode.rb
@@ -18,7 +18,7 @@ class XclipMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "xclip")
       (xclip-mode 1)

--- a/Formula/xcscope.rb
+++ b/Formula/xcscope.rb
@@ -16,7 +16,7 @@ class Xcscope < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/xcscope")
       (load "xcscope")
       (cscope-setup)

--- a/Formula/xml-rpc-emacs.rb
+++ b/Formula/xml-rpc-emacs.rb
@@ -16,7 +16,7 @@ class XmlRpcEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "xml-rpc")
       (print xml-rpc-version)

--- a/Formula/xpm-emacs.rb
+++ b/Formula/xpm-emacs.rb
@@ -18,7 +18,7 @@ class XpmEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "xpm")
       (print (minibuffer-prompt-width))

--- a/Formula/yaml-mode.rb
+++ b/Formula/yaml-mode.rb
@@ -33,7 +33,7 @@ class YamlMode < EmacsFormula
     doc.install "README"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Add the following to your init file:
 
     (require 'yaml-mode)
@@ -42,7 +42,7 @@ class YamlMode < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{share}/emacs/site-lisp/yaml-mode")
       (load "yaml-mode")
       (print (yaml-mode-version))

--- a/Formula/yasnippet.rb
+++ b/Formula/yasnippet.rb
@@ -33,7 +33,7 @@ class Yasnippet < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "yasnippet")
       (yas-global-mode 1)

--- a/Formula/zenburn-emacs.rb
+++ b/Formula/zenburn-emacs.rb
@@ -16,7 +16,7 @@ class ZenburnEmacs < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'custom-theme-load-path "#{elisp}")
       (load-theme 'zenburn t)
       (print (minibuffer-prompt-width))

--- a/Formula/ztree.rb
+++ b/Formula/ztree.rb
@@ -23,7 +23,7 @@ class Ztree < EmacsFormula
   end
 
   test do
-    (testpath/"test.el").write <<-EOS.undent
+    (testpath/"test.el").write <<~EOS
       (add-to-list 'load-path "#{elisp}")
       (load "ztree")
       (print (minibuffer-prompt-width))

--- a/cmd/brew-emacs.rb
+++ b/cmd/brew-emacs.rb
@@ -8,7 +8,7 @@ def template(name)
   classname = name.split("-").collect(&:capitalize).join
   # An added '-emacs' suffix probably isn't part of the actual package name
   name = name.gsub(/-emacs/, "")
-  <<-EOS.undent
+  <<~EOS
   require File.expand_path("../../Homebrew/emacs_formula", __FILE__)
 
   class #{classname} < EmacsFormula
@@ -28,7 +28,7 @@ def template(name)
     end
 
     test do
-      (testpath/"test.el").write <<-EOS.undent
+      (testpath/"test.el").write <<~EOS
         (add-to-list 'load-path "\#{elisp}")
         (load "#{name}")
         (print (minibuffer-prompt-width))


### PR DESCRIPTION
:wave: Hi Alex,
The `<<-EOS.undent` thing has been deprecated in Homebrew because recent versions of Ruby support `<<~EOS` that does the same.
I haven’t really tested this PR because I don’t use your tap :see_no_evil: 